### PR TITLE
Use a stream to pass client connection status in baby monitor

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/data/communication/websocket/ClientConnectionStatus.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/data/communication/websocket/ClientConnectionStatus.kt
@@ -1,0 +1,7 @@
+package co.netguru.baby.monitor.client.data.communication.websocket
+
+
+enum class ClientConnectionStatus {
+    EMPTY,
+    CLIENT_CONNECTED,
+}

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/data/communication/websocket/ServerStatus.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/data/communication/websocket/ServerStatus.kt
@@ -1,6 +1,0 @@
-package co.netguru.baby.monitor.client.data.communication.websocket
-
-
-enum class ServerStatus {
-    UNKNOWN, STARTED, STOPPED, ERROR, RETRYING
-}

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/receiver/WebRtcReceiverService.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/receiver/WebRtcReceiverService.kt
@@ -1,7 +1,6 @@
 package co.netguru.baby.monitor.client.feature.communication.webrtc.receiver
 
 import android.app.Service
-import android.arch.lifecycle.MutableLiveData
 import android.content.Intent
 import co.netguru.baby.monitor.client.common.NotificationHandler
 import co.netguru.baby.monitor.client.common.view.CustomSurfaceViewRenderer
@@ -9,7 +8,6 @@ import co.netguru.baby.monitor.client.data.DataRepository
 import co.netguru.baby.monitor.client.data.communication.ClientEntity
 import co.netguru.baby.monitor.client.data.communication.webrtc.CallState
 import co.netguru.baby.monitor.client.data.communication.websocket.MessageConfirmationStatus
-import co.netguru.baby.monitor.client.data.communication.websocket.ServerStatus
 import co.netguru.baby.monitor.client.feature.communication.webrtc.base.RtcCall
 import co.netguru.baby.monitor.client.feature.communication.webrtc.base.RtcCall.Companion.EVENT_RECEIVED_CONFIRMATION
 import co.netguru.baby.monitor.client.feature.communication.webrtc.base.RtcCall.Companion.P2P_OFFER
@@ -152,8 +150,9 @@ class WebRtcReceiverService : Service() {
     inner class WebRtcReceiverBinder : WebRtcBinder() {
 
         var currentCall: RtcReceiver? = null
-        val serverStatus: MutableLiveData<ServerStatus>
-            get() = this@WebRtcReceiverService.serverHandler.serverStatus
+
+        fun clientConnectionStatus() =
+                serverHandler.clientConnectionStatus()
 
         fun createReceiver(
                 view: CustomSurfaceViewRenderer,

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/server/ChildMonitorFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/server/ChildMonitorFragment.kt
@@ -18,7 +18,7 @@ import co.netguru.baby.monitor.client.common.extensions.bindService
 import co.netguru.baby.monitor.client.common.extensions.setVisible
 import co.netguru.baby.monitor.client.common.extensions.showSnackbarMessage
 import co.netguru.baby.monitor.client.data.communication.webrtc.CallState
-import co.netguru.baby.monitor.client.data.communication.websocket.ServerStatus
+import co.netguru.baby.monitor.client.data.communication.websocket.ClientConnectionStatus
 import co.netguru.baby.monitor.client.feature.communication.webrtc.receiver.WebRtcReceiverService
 import co.netguru.baby.monitor.client.feature.communication.webrtc.receiver.WebRtcReceiverService.WebRtcReceiverBinder
 import co.netguru.baby.monitor.client.feature.machinelearning.MachineLearningService
@@ -68,7 +68,6 @@ class ChildMonitorFragment : BaseDaggerFragment(), ServiceConnection {
     override fun onPause() {
         super.onPause()
         viewModel.unregisterNsdService()
-        pulsatingView.stop()
     }
 
     override fun onDestroy() {
@@ -174,11 +173,13 @@ class ChildMonitorFragment : BaseDaggerFragment(), ServiceConnection {
                     this@ChildMonitorFragment::handleCallStateChange
             )
         }
-        service.serverStatus.observe(this, Observer { status ->
-            if (status == ServerStatus.STARTED) {
-                pulsatingView.start()
-            } else {
-                pulsatingView.stop()
+        service.clientConnectionStatus().observe(this, Observer { status ->
+            Timber.d("Client status: $status.")
+            when (status) {
+                ClientConnectionStatus.CLIENT_CONNECTED ->
+                    pulsatingView.start()
+                ClientConnectionStatus.EMPTY ->
+                    pulsatingView.stop()
             }
         })
     }


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-423)
 
### Description
Instead of listeners, now indicator data is passed through a stream, and is properly handled by the consumer.
This could benefit of handling code structure complexity to be handled by a DI framework in the future (namely, not having to be passed from the server, through service and binder up to the view).
 
### Additional Notes (optional)
<!-- Provide any additional notes: quick tips for the reviewer, related PRs, screenshots, et al.). -->
 
### Checklist
<!-- Replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
 - [ ] I am following the [code style guide](https://netguru.atlassian.net/wiki/display/ANDROID/Android+best+practices)
 - [ ] The code includes tests of new features
 - [ ] The code passes static analysis
 - [ ] README.md is up to date
 - [ ] Version number is up to date
 - [ ] ProGuard configuration files are up to date
 - [ ] All temporary TODOs and FIXMEs are removed
 - [x] I have tested the solution on these devices:
  * Nexus 5X, Android 8.1
  * Nokia 7.1, Android 9.0
  
### Merge
<!-- Mark person(s) allowed to perform merge to the target branch with [x] (can be multiple) -->
 - [x] Committer
 - [x] Reviewer
 - [x] Project lead
