### PR TITLE
Add using multicastLock while discovering other services

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/ConnectingDevicesFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/ConnectingDevicesFragment.kt
@@ -1,11 +1,11 @@
 package co.netguru.baby.monitor.client.feature.client.configuration
 
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import android.net.wifi.p2p.WifiP2pManager
 import android.os.Bundle
 import android.view.View
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
@@ -21,7 +21,8 @@ import kotlinx.android.synthetic.main.fragment_connecting_devices.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-class ConnectingDevicesFragment : BaseDaggerFragment(), NsdServiceManager.OnServiceConnectedListener {
+class ConnectingDevicesFragment : BaseDaggerFragment(),
+    NsdServiceManager.OnServiceConnectedListener {
     override val layoutResource = R.layout.fragment_connecting_devices
 
     @Inject
@@ -36,7 +37,8 @@ class ConnectingDevicesFragment : BaseDaggerFragment(), NsdServiceManager.OnServ
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.connectionCompletedState.observe(viewLifecycleOwner, Observer { onConnectionCompleted(it) })
+        viewModel.connectionCompletedState.observe(viewLifecycleOwner,
+            Observer { onConnectionCompleted(it) })
         cancelSearchingButton.setOnClickListener {
             goBackToSpecifyDevice()
         }
@@ -44,7 +46,8 @@ class ConnectingDevicesFragment : BaseDaggerFragment(), NsdServiceManager.OnServ
 
     private fun goBackToSpecifyDevice() {
         findNavController()
-            .navigate(R.id.cancelConnecting, null,
+            .navigate(
+                R.id.cancelConnecting, null,
                 NavOptions.Builder()
                     .setPopUpTo(R.id.specifyDevice, true)
                     .build()
@@ -53,7 +56,7 @@ class ConnectingDevicesFragment : BaseDaggerFragment(), NsdServiceManager.OnServ
 
     override fun onStart() {
         super.onStart()
-        viewModel.discoverNsdService(this)
+        viewModel.discoverNsdService(this, requireContext())
         Single.timer(SEARCH_TIME_TILL_FAIL, TimeUnit.MINUTES)
             .subscribe { _ ->
                 findNavController().navigate(R.id.connectionFailed)

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/ConnectingDevicesFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/ConnectingDevicesFragment.kt
@@ -1,5 +1,7 @@
 package co.netguru.baby.monitor.client.feature.client.configuration
 
+import android.content.Context
+import android.net.wifi.WifiManager
 import android.net.wifi.p2p.WifiP2pManager
 import android.os.Bundle
 import android.view.View
@@ -56,12 +58,18 @@ class ConnectingDevicesFragment : BaseDaggerFragment(),
 
     override fun onStart() {
         super.onStart()
-        viewModel.discoverNsdService(this, requireContext())
+        discoverNsdService()
         Single.timer(SEARCH_TIME_TILL_FAIL, TimeUnit.MINUTES)
             .subscribe { _ ->
                 findNavController().navigate(R.id.connectionFailed)
             }
             .addTo(disposables)
+    }
+
+    private fun discoverNsdService() {
+        val wifiManager =
+            requireContext().applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        viewModel.discoverNsdService(this, wifiManager)
     }
 
     override fun onStop() {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/settings/ConfigurationViewModel.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/settings/ConfigurationViewModel.kt
@@ -1,12 +1,11 @@
 package co.netguru.baby.monitor.client.feature.settings
 
 import android.app.Activity
-import android.content.Context
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import android.content.Intent
 import android.net.wifi.WifiManager
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import co.netguru.baby.monitor.client.application.firebase.FirebaseRepository
 import co.netguru.baby.monitor.client.common.LocalDateTimeProvider
 import co.netguru.baby.monitor.client.common.RunsInBackground
@@ -75,16 +74,15 @@ class ConfigurationViewModel @Inject constructor(
 
     internal fun discoverNsdService(
         onServiceConnectedListener: NsdServiceManager.OnServiceConnectedListener,
-        context: Context
+        wifiManager: WifiManager
     ) {
-        acquireMulticastLock(context)
+        acquireMulticastLock(wifiManager)
         nsdServiceManager.discoverService(onServiceConnectedListener)
     }
 
-    private fun acquireMulticastLock(context: Context) {
+    private fun acquireMulticastLock(wifiManager: WifiManager) {
         // Pixel workaround for discovering services
-        val wifi = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-        multicastLock = wifi.createMulticastLock(MUTLICAST_LOCK_TAG)
+        multicastLock = wifiManager.createMulticastLock(MUTLICAST_LOCK_TAG)
         multicastLock?.setReferenceCounted(true)
         multicastLock?.acquire()
     }

--- a/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/settings/ConfigurationViewModelTest.kt
+++ b/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/settings/ConfigurationViewModelTest.kt
@@ -1,7 +1,6 @@
 package co.netguru.baby.monitor.client.feature.settings
 
 import android.app.Activity
-import android.content.Context
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
@@ -44,16 +43,10 @@ class ConfigurationViewModelTest {
         on { now() }.doReturn(localDateTime)
     }
     private val multicastLock: WifiManager.MulticastLock = mock()
-    private val context: Context = mock {
-        val applicationContext: Context = mock {
-            val wifiManager: WifiManager = mock {
-                on { createMulticastLock(ConfigurationViewModel.MUTLICAST_LOCK_TAG) }.doReturn(
-                    multicastLock
-                )
-            }
-            on { this.getSystemService(Context.WIFI_SERVICE) }.doReturn(wifiManager)
-        }
-        on { this.applicationContext }.doReturn(applicationContext)
+    private val wifiManager: WifiManager = mock {
+        on { createMulticastLock(ConfigurationViewModel.MUTLICAST_LOCK_TAG) }.doReturn(
+            multicastLock
+        )
     }
 
     @Before
@@ -111,7 +104,7 @@ class ConfigurationViewModelTest {
     @Test
     fun `should start and stop nsdService`() {
         val serviceConnectedListener: NsdServiceManager.OnServiceConnectedListener = mock()
-        configurationViewModel.discoverNsdService(serviceConnectedListener, context)
+        configurationViewModel.discoverNsdService(serviceConnectedListener, wifiManager)
 
         verify(nsdServiceManager).discoverService(serviceConnectedListener)
 
@@ -123,7 +116,7 @@ class ConfigurationViewModelTest {
     @Test
     fun `should handle Wifi MulticastLock while starting and stopping searching`() {
         val serviceConnectedListener: NsdServiceManager.OnServiceConnectedListener = mock()
-        configurationViewModel.discoverNsdService(serviceConnectedListener, context)
+        configurationViewModel.discoverNsdService(serviceConnectedListener, wifiManager)
 
         verify(multicastLock).acquire()
         verify(multicastLock).setReferenceCounted(true)


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-567)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
 Pixel devices couldn't find other devices while using network discovery service. This is a workaround for this issue. 