### PR TITLE
[BM-639] Delete action/value messages (unify with iOS)

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/SendFirebaseTokenUseCase.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/SendFirebaseTokenUseCase.kt
@@ -1,26 +1,21 @@
 package co.netguru.baby.monitor.client.feature.client.home
 
-import co.netguru.baby.monitor.client.feature.communication.webrtc.client.RtcClient.Companion.WEB_SOCKET_ACTION_KEY
+import co.netguru.baby.monitor.client.feature.communication.websocket.Message
 import co.netguru.baby.monitor.client.feature.communication.websocket.RxWebSocketClient
 import co.netguru.baby.monitor.client.feature.firebasenotification.FirebaseInstanceManager
-import co.netguru.baby.monitor.client.feature.firebasenotification.FirebaseInstanceManager.Companion.PUSH_NOTIFICATIONS_KEY
-import com.google.gson.JsonObject
+import com.google.gson.Gson
 import io.reactivex.Completable
 import javax.inject.Inject
 
 class SendFirebaseTokenUseCase @Inject constructor(
-    private val firebaseInstanceManager: FirebaseInstanceManager
+    private val firebaseInstanceManager: FirebaseInstanceManager,
+    private val gson: Gson
 ) {
 
     fun sendFirebaseToken(client: RxWebSocketClient): Completable =
         firebaseInstanceManager.getFirebaseToken()
             .flatMapCompletable { token ->
-                JsonObject()
-                    .apply {
-                        addProperty(WEB_SOCKET_ACTION_KEY, PUSH_NOTIFICATIONS_KEY)
-                        addProperty("value", token)
-                    }
-                    .toString()
+                gson.toJson(Message(pushNotificationsToken = token))
                     .let(client::send)
             }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/websocket/Message.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/websocket/Message.kt
@@ -3,23 +3,16 @@ package co.netguru.baby.monitor.client.feature.communication.websocket
 import com.google.gson.annotations.SerializedName
 
 data class Message(
-    @SerializedName("action") private val action: String? = null,
-    @SerializedName("value") private val value: String? = null,
+    @SerializedName("action") val action: String? = null,
     @SerializedName("offerSDP") val sdpOffer: SdpData? = null,
     @SerializedName("answerSDP") val sdpAnswer: SdpData? = null,
     @SerializedName("baby_name") val babyName: String? = null,
+    @SerializedName("pushNotificationsToken") val pushNotificationsToken: String? = null,
     @SerializedName("iceCandidate") val iceCandidate: IceCandidateData? = null,
     @SerializedName("errorSDP") val sdpError: String? = null,
     @SerializedName("pairingCode") val pairingCode: String? = null,
     @SerializedName("pairingResponse") val pairingApproved: Boolean? = null
 ) {
-    fun action() =
-        if (action != null && value != null) {
-            action to value
-        } else {
-            null
-        }
-
     data class SdpData(
         @SerializedName("sdp") val sdp: String,
         @SerializedName("type") val type: String

--- a/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/client/home/SendFirebaseTokenUseCaseTest.kt
+++ b/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/client/home/SendFirebaseTokenUseCaseTest.kt
@@ -1,7 +1,9 @@
 package co.netguru.baby.monitor.client.feature.client.home
 
+import co.netguru.baby.monitor.client.feature.communication.websocket.Message
 import co.netguru.baby.monitor.client.feature.communication.websocket.RxWebSocketClient
 import co.netguru.baby.monitor.client.feature.firebasenotification.FirebaseInstanceManager
+import com.google.gson.Gson
 import com.nhaarman.mockitokotlin2.*
 import io.reactivex.Completable
 import io.reactivex.Single
@@ -16,7 +18,10 @@ class SendFirebaseTokenUseCaseTest {
     private val rxWebSocketClient: RxWebSocketClient = mock {
         on { send(any()) }.doReturn(Completable.complete())
     }
-    private val sendFirebaseTokenUseCase = SendFirebaseTokenUseCase(firebaseInstanceManager)
+    private val gson: Gson = mock {
+        on { toJson(any<Message>()) }.doReturn(token)
+    }
+    private val sendFirebaseTokenUseCase = SendFirebaseTokenUseCase(firebaseInstanceManager, gson)
 
     @Test
     fun sendFirebaseToken() {

--- a/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/server/ChildMonitorViewModelTest.kt
+++ b/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/server/ChildMonitorViewModelTest.kt
@@ -7,7 +7,6 @@ import co.netguru.baby.monitor.client.data.communication.websocket.ClientConnect
 import co.netguru.baby.monitor.client.feature.batterylevel.NotifyLowBatteryUseCase
 import co.netguru.baby.monitor.client.feature.communication.websocket.Message
 import co.netguru.baby.monitor.client.feature.communication.websocket.WebSocketServerService
-import co.netguru.baby.monitor.client.feature.firebasenotification.FirebaseInstanceManager.Companion.PUSH_NOTIFICATIONS_KEY
 import com.nhaarman.mockitokotlin2.*
 import dagger.Lazy
 import io.reactivex.Completable
@@ -58,30 +57,14 @@ class ChildMonitorViewModelTest {
         ChildMonitorViewModel(lazyReceiveFirebaseTokenUseCase, notifyLowBatteryUseCase)
 
     @Test
-    fun `should send Firebase token on PUSH_NOTIFICATIONS_KEY Websocket action`() {
-        val message: Message = mock {
-            on { action() }.doReturn(PUSH_NOTIFICATIONS_KEY to firebaseToken)
-        }
+    fun `should handle Firebase token`() {
+        val message = Message(pushNotificationsToken = firebaseToken)
         whenever(webSocketServiceBinder.messages()).doReturn(Observable.just(websocket to message))
 
         childViewModel.handleWebSocketServerBinder(webSocketServiceBinder)
 
         verify(lazyReceiveFirebaseTokenUseCase).get()
         verify(receiveFirebaseTokenUseCase).receiveToken(deviceAddress, firebaseToken)
-    }
-
-    @Test
-    fun `should not send Firebase token on key that isn't PUSH_NOTIFICATIONS_KEY`() {
-        val notPushNotificationKey = "notPushNotificationKey"
-        val message: Message = mock {
-            on { action() }.doReturn(notPushNotificationKey to firebaseToken)
-        }
-        whenever(webSocketServiceBinder.messages()).doReturn(Observable.just(websocket to message))
-
-        childViewModel.handleWebSocketServerBinder(webSocketServiceBinder)
-
-        verifyZeroInteractions(lazyReceiveFirebaseTokenUseCase)
-        verifyZeroInteractions(receiveFirebaseTokenUseCase)
     }
 
     @Test
@@ -130,7 +113,6 @@ class ChildMonitorViewModelTest {
         val name = "babyName"
         val babyNameObserver: Observer<String> = mock()
         val message: Message = mock {
-            on { action() }.doReturn("" to "")
             on { babyName }.doReturn(name)
         }
         whenever(webSocketServiceBinder.messages()).doReturn(Observable.just(websocket to message))


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-639)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
 In order to unify webSocket message handling we decided to delete 
the `{action: String ,value: String}` in favor of `{fieldName: Type}` messages. 