### PR TITLE
[BM-610] Add onBack custom handling to failed connection fragment

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/ConnectingDevicesFailedFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/ConnectingDevicesFailedFragment.kt
@@ -2,6 +2,7 @@ package co.netguru.baby.monitor.client.feature.communication.pairing
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
@@ -15,5 +16,15 @@ class ConnectingDevicesFailedFragment : BaseFragment() {
         configurationFailedTryAgainButton.setOnClickListener {
             findNavController().navigate(R.id.connectionFailedToServiceDiscovery)
         }
+        setupOnBackPressedHandling()
+    }
+
+    private fun setupOnBackPressedHandling() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object :
+            OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                findNavController().navigate(R.id.connectionFailedToServiceDiscovery)
+            }
+        })
     }
 }


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-610)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
 Custom onBackPressed handling : return to new pairing instance with clean state.