### PR TITLE
[BM-613] Android baby device crash fix

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/livecamera/ClientLiveCameraFragmentViewModel.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/livecamera/ClientLiveCameraFragmentViewModel.kt
@@ -84,6 +84,6 @@ class ClientLiveCameraFragmentViewModel @Inject constructor(
             RtcConnectionState.Error -> analyticsManager.logEvent(Event.Simple(EventType.VIDEO_STREAM_ERROR))
             else -> Unit
         }
-        mutableStreamState.value = streamState
+        mutableStreamState.postValue(streamState)
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/client/RtcClient.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/client/RtcClient.kt
@@ -81,15 +81,15 @@ class RtcClient(
         PeerConnectionFactory.initialize(
             PeerConnectionFactory.InitializationOptions.builder(context)
                 .setEnableInternalTracer(false)
-                .setEnableVideoHwAcceleration(true)
                 .createInitializationOptions()
         )
         Timber.i("initialized")
+        val encoderFactory = DefaultVideoEncoderFactory(sharedContext, true, false)
+        val decoderFactory = DefaultVideoDecoderFactory(sharedContext)
         val factory = PeerConnectionFactory.builder()
+            .setVideoEncoderFactory(encoderFactory)
+            .setVideoDecoderFactory(decoderFactory)
             .createPeerConnectionFactory()
-            .apply {
-                setVideoHwAccelerationOptions(sharedContext, sharedContext)
-            }
         Timber.i("created")
         constraints = MediaConstraints().apply {
             mandatory.add(MediaConstraints.KeyValuePair(HANDSHAKE_AUDIO_OFFER, "true"))

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -34,7 +34,7 @@ ext {
             navigationUiKtx     : "androidx.navigation:navigation-ui-ktx:$navigationVersion",
             tensorFlow          : "org.tensorflow:tensorflow-android:1.13.1",
             javaWebSocket       : "org.java-websocket:Java-WebSocket:1.4.0",
-            googleWebRtc        : 'org.webrtc:google-webrtc:1.0.22672',
+            googleWebRtc        : 'org.webrtc:google-webrtc:1.0.30039',
             room                : "androidx.room:room-runtime:$roomVersion",
             roomRx              : "androidx.room:room-rxjava2:$roomVersion",
             firebaseStorage     : 'com.google.firebase:firebase-storage:19.1.0',


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-613)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
 WebRtc update with additional live data post value fix.
The main crash was caused by some native code memory error. Updating the WebRTC library fixed the issue. 
