### PR TITLE
[BM-658] webRTC audio release

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/nsd/NsdServiceManager.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/nsd/NsdServiceManager.kt
@@ -77,7 +77,7 @@ class NsdServiceManager @Inject constructor(
         }
         this.nsdDiscoveryObservable = nsdDiscoveryObservable
 
-        nsdDiscoveryObservable.subscribeOn(Schedulers.computation())
+        nsdDiscoveryObservable.subscribeOn(Schedulers.io())
             .concatMapSingle(this::createResolveServiceSingle)
             .subscribeBy(onNext = this::handleResolvedService,
                 onError = {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/server/WebRtcManager.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/server/WebRtcManager.kt
@@ -180,7 +180,7 @@ class WebRtcManager constructor(
 
     private fun addStream() {
         Timber.i("Add stream")
-        if (stream != null) disposeStream() //If parent enters/exits stream very quick
+        if (stream != null) disposeStream() // If parent enters/exits stream very quick
         initAudio()
         stream = peerConnectionFactory.createLocalMediaStream(STREAM_LABEL)
         stream?.addTrack(audioTrack)
@@ -219,8 +219,8 @@ class WebRtcManager constructor(
     fun getConnectionObservable(): Observable<RtcConnectionState> =
         connectionObserver.streamObservable.ofType(ConnectionState::class.java)
             .doOnNext {
-                if (it.connectionState is RtcConnectionState.Disconnected
-                    || it.connectionState is RtcConnectionState.Error
+                if (it.connectionState is RtcConnectionState.Disconnected ||
+                    it.connectionState is RtcConnectionState.Error
                 ) disposeStream()
             }
             .flatMap { Observable.just(it.connectionState) }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/server/WebRtcManager.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/server/WebRtcManager.kt
@@ -21,10 +21,11 @@ class WebRtcManager constructor(
     private var cameraVideoCapturer: CameraVideoCapturer? = null
     private lateinit var videoSource: VideoSource
     private lateinit var videoTrack: VideoTrack
-    private lateinit var audioSource: AudioSource
-    private lateinit var audioTrack: AudioTrack
+    private var audioSource: AudioSource? = null
+    private var audioTrack: AudioTrack? = null
 
     private var peerConnection: PeerConnection? = null
+    private var stream: MediaStream? = null
     private var compositeDisposable: CompositeDisposable = CompositeDisposable()
     private lateinit var connectionObserver: ConnectionObserver
 
@@ -80,16 +81,15 @@ class WebRtcManager constructor(
             .setVideoEncoderFactory(encoderFactory)
             .createPeerConnectionFactory()
 
-        val surfaceTextureHelper = SurfaceTextureHelper.create(SURFACE_TEXTURE_HELPER_THREAD, sharedContext)
+        val surfaceTextureHelper =
+            SurfaceTextureHelper.create(SURFACE_TEXTURE_HELPER_THREAD, sharedContext)
         videoSource = peerConnectionFactory.createVideoSource(true)
         cameraVideoCapturer = createCameraCapturer(Camera2Enumerator(context))
             .apply {
                 initialize(surfaceTextureHelper, context, videoSource.capturerObserver)
             }
 
-        videoTrack = peerConnectionFactory.createVideoTrack("video", videoSource)
-        audioSource = peerConnectionFactory.createAudioSource(MediaConstraints())
-        audioTrack = peerConnectionFactory.createAudioTrack("audio", audioSource)
+        videoTrack = peerConnectionFactory.createVideoTrack(VIDEO_TRACK_ID, videoSource)
         cameraVideoCapturer?.let { enableVideo(true, it) }
         createConnection()
     }
@@ -101,12 +101,12 @@ class WebRtcManager constructor(
             emptyList(),
             connectionObserver
         )
-        val stream = peerConnectionFactory.createLocalMediaStream("stream")
-        stream.addTrack(audioTrack)
-        stream.addTrack(videoTrack)
-        peerConnection?.addStream(stream)
-
         listenForIceCandidates(connectionObserver.streamObservable)
+    }
+
+    private fun initAudio() {
+        audioSource = peerConnectionFactory.createAudioSource(MediaConstraints())
+        audioTrack = peerConnectionFactory.createAudioTrack(AUDIO_TRACK_ID, audioSource)
     }
 
     private fun listenForIceCandidates(streamObservable: Observable<StreamState>) {
@@ -138,7 +138,7 @@ class WebRtcManager constructor(
     fun stopCapturing() {
         Timber.d("stopCapturing()")
         compositeDisposable.dispose()
-        audioSource.dispose()
+        audioSource?.dispose()
         videoSource.dispose()
         cameraVideoCapturer?.dispose()
         peerConnection?.dispose()
@@ -148,6 +148,7 @@ class WebRtcManager constructor(
     fun acceptOffer(offer: String) {
         Timber.i("acceptOffer($offer)")
         connectionObserver.onAcceptOffer()
+        addStream()
         peerConnection?.run {
             setRemoteDescription(SessionDescription(SessionDescription.Type.OFFER, offer))
                 .doOnComplete { Timber.d("Offer set as a remote description.") }
@@ -177,6 +178,29 @@ class WebRtcManager constructor(
         }?.addTo(compositeDisposable)
     }
 
+    private fun addStream() {
+        Timber.i("Add stream")
+        if (stream != null) disposeStream() //If parent enters/exits stream very quick
+        initAudio()
+        stream = peerConnectionFactory.createLocalMediaStream(STREAM_LABEL)
+        stream?.addTrack(audioTrack)
+        stream?.addTrack(videoTrack)
+        peerConnection?.addStream(stream)
+    }
+
+    private fun disposeStream() {
+        Timber.i("Dispose stream")
+        disposeAudio()
+        peerConnection?.removeStream(stream)
+        stream = null
+    }
+
+    private fun disposeAudio() {
+        audioTrack?.dispose()
+        audioSource?.dispose()
+        audioSource = null
+    }
+
     fun addIceCandidate(iceCandidateData: Message.IceCandidateData) {
         peerConnection?.addIceCandidate(
             IceCandidate(
@@ -194,12 +218,20 @@ class WebRtcManager constructor(
 
     fun getConnectionObservable(): Observable<RtcConnectionState> =
         connectionObserver.streamObservable.ofType(ConnectionState::class.java)
+            .doOnNext {
+                if (it.connectionState is RtcConnectionState.Disconnected
+                    || it.connectionState is RtcConnectionState.Error
+                ) disposeStream()
+            }
             .flatMap { Observable.just(it.connectionState) }
 
     companion object {
         private const val VIDEO_HEIGHT = 480
         private const val VIDEO_WIDTH = 320
         private const val VIDEO_FRAMERATE = 30
+        private const val STREAM_LABEL = "stream"
+        private const val AUDIO_TRACK_ID = "audio"
+        private const val VIDEO_TRACK_ID = "video"
         private const val SURFACE_TEXTURE_HELPER_THREAD = "SURFACE_TEXTURE_HELPER_THREAD"
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/machinelearning/AacRecorder.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/machinelearning/AacRecorder.kt
@@ -46,6 +46,7 @@ class AacRecorder {
     }
 
     fun release() {
+        Timber.i("release recording")
         shouldStopRecording = true
         audioRecord?.stop()
         audioRecord?.release()

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/machinelearning/MachineLearningService.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/machinelearning/MachineLearningService.kt
@@ -116,14 +116,9 @@ class MachineLearningService : IntentService("MachineLearningService") {
 
     inner class MachineLearningBinder : Binder() {
         fun startRecording() {
-            stopIfRunning()
+            if (aacRecorder != null) return
             Timber.i("Start recording")
             this@MachineLearningService.startRecording()
-        }
-
-        private fun stopIfRunning() {
-            // In case of multiple disconnected statuses from RtcServerConnectionState
-            if (aacRecorder != null) stopRecording()
         }
 
         fun stopRecording() {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/server/ServerViewModel.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/server/ServerViewModel.kt
@@ -69,7 +69,7 @@ class ServerViewModel @Inject constructor(
         timerDisposable?.dispose()
         timerDisposable = Observable.intervalRange(
             1, VIDEO_PREVIEW_TOTAL_TIME, 0, 1, TimeUnit.SECONDS,
-            schedulersProvider.computation()
+            schedulersProvider.io()
         )
             .observeOn(schedulersProvider.mainThread())
             .subscribeBy(
@@ -161,7 +161,10 @@ class ServerViewModel @Inject constructor(
                     handleStreamState(it)
                     mutableRtcConnectionStatus.postValue(it)
                 },
-                onError = { mutableRtcConnectionStatus.postValue(RtcConnectionState.Error) }
+                onError = {
+                    mutableRtcConnectionStatus.postValue(RtcConnectionState.Error)
+                    Timber.e(it)
+                }
             )
     }
 

--- a/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/server/ServerViewModelTest.kt
+++ b/app/src/test/kotlin/co/netguru/baby/monitor/client/feature/server/ServerViewModelTest.kt
@@ -42,7 +42,7 @@ class ServerViewModelTest {
     private val schedulersProvider: ISchedulersProvider = mock {
         on { io() } doReturn Schedulers.trampoline()
         on { mainThread() } doReturn Schedulers.trampoline()
-        on { computation() } doReturn timerTestScheduler
+        on { computation() } doReturn Schedulers.trampoline()
     }
     private val deviceAddress = "deviceAddress"
     private val firebaseToken = "firebaseToken"
@@ -83,6 +83,7 @@ class ServerViewModelTest {
     @Test
     fun `should disable preview after VIDEO_PREVIEW_TOTAL_TIME`() {
         val cameraStateObserver: Observer<CameraState> = mock()
+        whenever(schedulersProvider.io()).doReturn(timerTestScheduler)
         serverViewModel.cameraState.observeForever(cameraStateObserver)
 
         assert(serverViewModel.cameraState.value?.previewEnabled == true)
@@ -97,6 +98,7 @@ class ServerViewModelTest {
     fun `should update timer value`() {
         val passedTime = 5L
         val startingFromOne = 1
+        whenever(schedulersProvider.io()).doReturn(timerTestScheduler)
 
         serverViewModel.resetTimer()
         timerTestScheduler.advanceTimeBy(passedTime, TimeUnit.SECONDS)


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-658)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
 After webRTC update issue came up that caused audio resources to be
blocked by webRTC which made AudioRecording and ML analysis impossible.
We need to init audioSource before stream starts and dispose them after
stream fails/disconnects.