### PR TITLE
[BM-658] Stream and audio release checks.

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/server/WebRtcManager.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/server/WebRtcManager.kt
@@ -180,7 +180,7 @@ class WebRtcManager constructor(
 
     private fun addStream() {
         Timber.i("Add stream")
-        if (stream != null) disposeStream() // If parent enters/exits stream very quick
+        disposeStream() // If parent enters/exits stream very quick
         initAudio()
         stream = peerConnectionFactory.createLocalMediaStream(STREAM_LABEL)
         stream?.addTrack(audioTrack)
@@ -189,6 +189,10 @@ class WebRtcManager constructor(
     }
 
     private fun disposeStream() {
+        if (stream == null) {
+            Timber.i("Stream already disposed")
+            return
+        }
         Timber.i("Dispose stream")
         disposeAudio()
         peerConnection?.removeStream(stream)
@@ -198,6 +202,7 @@ class WebRtcManager constructor(
     private fun disposeAudio() {
         audioTrack?.dispose()
         audioSource?.dispose()
+        audioTrack = null
         audioSource = null
     }
 


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-658)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
Added null check for stream and nullifying audioTrack.
 In current implementation WebRTC disconnects from the stream and
returns failed state after some time. So we need to check if the
stream was disposed earlier.