### PR TITLE
[BM-676] Manage the client websocket connection within activity onResume/onPause

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/ClientHomeActivity.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/ClientHomeActivity.kt
@@ -53,7 +53,16 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
 
         homeViewModel.fetchLogData()
         homeViewModel.checkInternetConnection()
+    }
+
+    override fun onResume() {
+        super.onResume()
         homeViewModel.openSocketConnection { address -> URI.create(address) }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        homeViewModel.closeSocketConnection()
     }
 
     private fun setupObservers() {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/dashboard/ClientDashboardFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/dashboard/ClientDashboardFragment.kt
@@ -75,7 +75,7 @@ class ClientDashboardFragment : BaseFragment() {
     }
 
     private fun showClientConnected() {
-        clientConnectionStatusTv.text = getString(R.string.monitoring_enabled)
+        clientConnectionStatusTv.text = getString(R.string.devices_connected)
         clientConnectionStatusPv.start()
         clientHomeLiveCameraIbtn.setOnClickListener {
             requestMicrophonePermission()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="nsd_service_registration_failed">Device discovery registration failed</string>
 
     <string name="devices_disconnected">Devices disconnected</string>
-    <string name="monitoring_enabled">Monitoring enabled</string>
+    <string name="devices_connected">Devices connected</string>
     <string name="parent">Parent</string>
     <string name="parent_button_description">This device will stay \nwith me</string>
     <string name="baby">Baby</string>


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-676)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
Establish connection within activity lifecycle events - onResume, onPause in order to properly handle going/returning to/from background. 
Additionally changed string to match the connection status.
 