### PR TITLE
[BM-678] Unify websocket connection timeout between parent and baby device

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/websocket/CustomWebSocketServer.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/websocket/CustomWebSocketServer.kt
@@ -21,7 +21,7 @@ class CustomWebSocketServer(
 
     init {
         isReuseAddr = true
-        connectionLostTimeout = 10
+        connectionLostTimeout = CONNECTION_LOST_TIMEOUT
     }
 
     private fun updateConnectedClients() {
@@ -72,5 +72,6 @@ class CustomWebSocketServer(
 
     companion object {
         internal const val PORT = 63124
+        const val CONNECTION_LOST_TIMEOUT = 10
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/websocket/RxWebSocketClient.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/websocket/RxWebSocketClient.kt
@@ -1,5 +1,6 @@
 package co.netguru.baby.monitor.client.feature.communication.websocket
 
+import co.netguru.baby.monitor.client.feature.communication.websocket.CustomWebSocketServer.Companion.CONNECTION_LOST_TIMEOUT
 import com.google.gson.Gson
 import dagger.Reusable
 import io.reactivex.Completable
@@ -67,6 +68,10 @@ class RxWebSocketClient @Inject constructor(
     }
 
     private class RxWebSocketClient(serverUri: URI) : WebSocketClient(serverUri) {
+
+        init {
+            connectionLostTimeout = CONNECTION_LOST_TIMEOUT
+        }
 
         private val events: Subject<Event> = PublishSubject.create()
 


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-678)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
We unified the value in order to avoid situations when baby got
disconnected status and parent is still "connected"