### PR TITLE
[BM-685] Huawei recording data chunks fix

### DIFF
--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/voiceAnalysis/RecordingController.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/voiceAnalysis/RecordingController.kt
@@ -26,8 +26,8 @@ class RecordingController @Inject constructor(
             .map {
                 val data = when {
                     isMachineLearningWithEnoughData(it) -> RecordingData.MachineLearning(
-                        it.first.toByteArray(),
-                        it.second.toShortArray()
+                        it.first.takeLast(MachineLearning.DATA_SIZE * 2).toByteArray(),
+                        it.second.takeLast(MachineLearning.DATA_SIZE).toShortArray()
                     )
                     isNoiseDetectionWithEnoughData(it) -> RecordingData.NoiseDetection(
                         it.second.takeLast(NoiseDetector.DATA_SIZE).toShortArray()
@@ -44,7 +44,7 @@ class RecordingController @Inject constructor(
 
     private fun isMachineLearningWithEnoughData(it: Pair<Array<Byte>, Array<Short>>) =
         voiceAnalysisOption == VoiceAnalysisOption.MACHINE_LEARNING &&
-                it.second.size == MachineLearning.DATA_SIZE
+                it.second.size >= MachineLearning.DATA_SIZE
 
     private fun addData(
         accumulator: Pair<Array<Byte>, Array<Short>>,


### PR DESCRIPTION
### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/BM-685)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
Check equal/bigger recording size, take the amount needed for analysis.
There was problem with huawei devices, recording data is coming in
different chunks than on other devices which causes the ML data check
to be false all the time (because of the "==" data size check)